### PR TITLE
eat: update to wpilib 23.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Changed
 
 - desktop shortcut is now trusted by default
+- updated to WPILib 2023.1.1
 
 ## [1.0.0] - 2022-11-05
 

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -14,7 +14,7 @@ ENV {{ var }} {{ value }}
 {% endfor %}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then                                                        apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 init && apt-get clean; \
+RUN if [ $(command -v apt-get) ]; then                                                        apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 init && apt-get clean; \
     elif [ $(command -v zypper) ]; then                                                       zypper refresh && zypper install -y python sudo bash python-xml iproute2 systemd-sysvinit && zypper clean -a; \
     elif [ $(command -v apk) ]; then                                                          apk update && apk add --no-cache python sudo bash ca-certificates; \
     elif [ $(command -v xbps-install) ]; then                                                 xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; \

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,6 +18,9 @@ platforms:
   - name: ubuntu-focal
     image: library/ubuntu:20.04
     pre_build_image: false
+  - name: ubuntu-jammy
+    image: library/ubuntu:22.04
+    pre_build_image: false
 
 provisioner:
   name: ansible

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible-compat==2.2.4
+ansible-compat==2.2.6
 ansible-core==2.13.5
-ansible-lint==6.8.6
+ansible-lint==6.9.0
 arrow==1.2.3
 attrs==22.1.0
 binaryornot==0.4.4

--- a/roles/wpilib/README.md
+++ b/roles/wpilib/README.md
@@ -9,12 +9,7 @@ which is particularly useful when using shared workstations.
 
 ## Requirements
 
-These roles are only tested using Ubuntu/PopOS 20.04 Focal with GNOME desktop.
-
-Experiments indicate that the most recent FRC tools (2022.04.1) is incompatible
-with Ubuntu/PopOS 22.04 Jammy. The install is successful, but certain tools
-won't work, e.g., the robot simulator. It's likely that support for more recent
-distributions will come with FRC tools for the 2023 season.
+These roles are only tested using Ubuntu/PopOS 20.04 Focal and 22.04 Jammy.
 
 This role has been tested for Java projects only. C++ projects may not work.
 
@@ -22,8 +17,8 @@ This role has been tested for Java projects only. C++ projects may not work.
 
 | variable                 | description                                               | default/example                                   |
 | ------------------------ | --------------------------------------------------------- | ------------------------------------------------- |
-| `wpilib_release_version` | WPILib release version                                    | `2022.4.1`                                        |
-| `wpilib_release_hash`    | WPILib release version hash (usually a sha256 or md5)     | `md5:fe77..`                                      |
+| `wpilib_release_version` | WPILib release version                                    | `2023.1.1`                                        |
+| `wpilib_release_hash`    | WPILib release version hash (usually a sha256 or md5)     | `md5:07c3..`                                      |
 | `wpilib_install_root`    | Directory to store WPILib archives prior to user installs | `/usr/local/wpilib`                               |
 | `wpilib_users`           | A list of users that will get a WPILib installation       | `{{ ansible_env.USER }}` (i.e., the current user) |
 
@@ -67,4 +62,3 @@ several ways:
 ## Known Issues
 
 - user install includes more directories than is strictly necessary
-- included gradle is not installed into cache location

--- a/roles/wpilib/defaults/main.yml
+++ b/roles/wpilib/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-wpilib_release_version: "2022.4.1"
-wpilib_release_hash: "md5:fe77f689d5da5f5d3b167f5ae50429b2"
+wpilib_release_version: "2023.1.1"
+wpilib_release_hash: "md5:07c3db6a4fb11d4d23ed8a833b68a2fa"
 
 wpilib_install_root: /usr/local/wpilib
 


### PR DESCRIPTION
feat: update to wpilib 23.1.1
    
Updated the default install of wpilib to 23.1.1. With this release,
wpilib has dropped active support for Ubuntu 18 through 20 and now only
actively supports Ubuntu 22.04 (jammy jellyfish). Tests have been
updated to support both 20.04 and 22.04 for this collection.